### PR TITLE
JS fix

### DIFF
--- a/assets/javascript/logic.js
+++ b/assets/javascript/logic.js
@@ -114,9 +114,9 @@ $(document).ready(function() {
       console.log("logged in");
     } else {
       console.log("not logged in");
-      setTimeout(function() {
-        window.location.href = "login.html";
-      }, 1000);
+      // setTimeout(function() {
+      //   window.location.href = "login.html";
+      // }, 1000);
     }
   });
 });


### PR DESCRIPTION
- setTimeout function in Authentication event listener was causing page to reload when it detected that user wasn't logged in 